### PR TITLE
Fix cell error in image_analysis.ipynb

### DIFF
--- a/webinar1/image_analysis.ipynb
+++ b/webinar1/image_analysis.ipynb
@@ -306,7 +306,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!ls {folders_list[0]}"
+    "!ls {os.path.join(nuclei_data_path, folders_list[0])}"
    ]
   },
   {


### PR DESCRIPTION
This notebook cell gave a "path not found" error. We have added the directory prefix to the filepath to fix this here.

Follow up to webinar Monday 8th May - bug found by several students during the webinar.