### PR TITLE
Possible typo in notebook 2_logistic_regression.ipynb

### DIFF
--- a/webinar2/pytorch/2_logistic_regression.ipynb
+++ b/webinar2/pytorch/2_logistic_regression.ipynb
@@ -880,7 +880,7 @@
     "- Train a model with more preset filters and compare the different models via tensorboard and on the test dataset.\n",
     "- The filters we have used here can be expressed as convolutions.\n",
     "    - Express the `gaussian` filter using [nn.Conv2d](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html) and train a model using these filters.\n",
-    "    - Can you also explace the `laplace` filter?"
+    "    - Can you also explain the `laplace` filter?"
    ]
   }
  ],


### PR DESCRIPTION
I think "explace" in this sentence should be "explain" instead, is that correct?