### PR TITLE
Add missing !pip install cifar2png

### DIFF
--- a/webinar2/pytorch/1_data_preperation.ipynb
+++ b/webinar2/pytorch/1_data_preperation.ipynb
@@ -79,6 +79,7 @@
    },
    "outputs": [],
    "source": [
+    "!pip install cifar2png"
     "cifar_dir = './cifar10'\n",
     "!cifar2png cifar10 cifar10"
    ]


### PR DESCRIPTION
Some jupyter notebooks weren't working in colab because the cifar2png package wasn't installed.